### PR TITLE
Handle API cooldowns and Turnstile imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 
 public/stockfish/stockfish-18-single.js
 public/stockfish/stockfish-18-single.wasm
+.vercel

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Point it at an analysis API with:
 VITE_G6_API_BASE_URL=http://127.0.0.1:8001
 ```
 
+Enable Cloudflare Turnstile for anonymous import starts with:
+
+```bash
+VITE_G6_TURNSTILE_SITE_KEY=...
+```
+
 Expected API shape today:
 
 - `POST /api/game-analysis/import`

--- a/src/components/analysis/AnalysisImportPanel.tsx
+++ b/src/components/analysis/AnalysisImportPanel.tsx
@@ -1,6 +1,13 @@
 import { ArrowUp, RotateCw, Smile } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
-import { type FormEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   isSupportedChessComAnalysisUrl,
   normalizeChessComImportUrl,
@@ -22,6 +29,7 @@ interface AnalysisImportPanelProps {
 type Mode = "url" | "pgn";
 
 const DEFAULT_EXPLAIN_SIGNIFICANCE: readonly SignificanceLabel[] = ["critical"];
+const TURNSTILE_SITE_KEY = String(import.meta.env.VITE_G6_TURNSTILE_SITE_KEY ?? "").trim();
 
 const FIELD_HEIGHT_URL = 46;
 const FIELD_HEIGHT_PGN = 232;
@@ -45,11 +53,16 @@ export function AnalysisImportPanel({
   const [url, setUrl] = useState(() => initialUrl ?? "");
   const [pgn, setPgn] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
 
   const isBusy = status === "submitting" || status === "polling";
+  const needsTurnstile = TURNSTILE_SITE_KEY.length > 0;
   const displayedError = localError ?? error;
   const value = mode === "url" ? url : pgn;
-  const canSubmit = !isBusy && isValidInput(mode, value);
+  const canSubmit =
+    !isBusy && isValidInput(mode, value) && (!needsTurnstile || turnstileToken !== null);
+  const handleTurnstileExpire = useCallback(() => setTurnstileToken(null), []);
 
   function clearErrors() {
     setLocalError(null);
@@ -63,9 +76,13 @@ export function AnalysisImportPanel({
     }
     setLocalError(null);
     try {
-      await onImport(buildRequest(mode, { url: url.trim(), pgn }));
+      await onImport(buildRequest(mode, { url: url.trim(), pgn, turnstileToken }));
     } catch (err) {
       setLocalError(importErrorMessage(err));
+      if (needsTurnstile) {
+        setTurnstileToken(null);
+        setTurnstileResetKey((current) => current + 1);
+      }
     }
   }
 
@@ -104,6 +121,17 @@ export function AnalysisImportPanel({
           value={value}
         />
       </form>
+
+      {needsTurnstile ? (
+        <div className="mt-3 flex justify-center">
+          <TurnstileWidget
+            key={turnstileResetKey}
+            onExpire={handleTurnstileExpire}
+            onToken={setTurnstileToken}
+            siteKey={TURNSTILE_SITE_KEY}
+          />
+        </div>
+      ) : null}
 
       <div className="mt-2 flex items-center justify-between gap-3 px-1">
         <ModeToggle
@@ -389,17 +417,24 @@ function isValidPgn(value: string): boolean {
   return PGN_TAG_PATTERN.test(trimmed) || PGN_MOVE_PATTERN.test(trimmed);
 }
 
-function buildRequest(mode: Mode, values: { url: string; pgn: string }): GameAnalysisImportRequest {
+function buildRequest(
+  mode: Mode,
+  values: { url: string; pgn: string; turnstileToken: string | null },
+): GameAnalysisImportRequest {
   const sourceFields =
     mode === "url"
       ? ({ source: "chess_com_live_url", url: normalizeChessComImportUrl(values.url) } as const)
       : ({ source: "pgn", pgn: values.pgn } as const);
-  return {
+  const request: GameAnalysisImportRequest = {
     ...sourceFields,
     explain_significance: [...DEFAULT_EXPLAIN_SIGNIFICANCE],
     include_context: true,
     use_baseline_fallback: false,
   };
+  if (values.turnstileToken !== null) {
+    request.turnstile_token = values.turnstileToken;
+  }
+  return request;
 }
 
 function importErrorMessage(error: unknown): string {
@@ -410,4 +445,89 @@ function importErrorMessage(error: unknown): string {
     return error.message;
   }
   return "Import failed.";
+}
+
+interface TurnstileApi {
+  render: (
+    container: HTMLElement,
+    options: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "expired-callback": () => void;
+      "error-callback": () => void;
+      theme: "auto";
+    },
+  ) => string;
+  remove?: (widgetId: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+    __g6TurnstileScriptLoading?: boolean;
+  }
+}
+
+function TurnstileWidget({
+  siteKey,
+  onToken,
+  onExpire,
+}: {
+  siteKey: string;
+  onToken: (token: string) => void;
+  onExpire: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let widgetId: string | null = null;
+    let timer: number | undefined;
+    ensureTurnstileScript();
+
+    function renderWhenReady() {
+      const container = containerRef.current;
+      if (!container || widgetId !== null || !window.turnstile) {
+        return;
+      }
+      widgetId = window.turnstile.render(container, {
+        sitekey: siteKey,
+        callback: onToken,
+        "expired-callback": onExpire,
+        "error-callback": onExpire,
+        theme: "auto",
+      });
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+        timer = undefined;
+      }
+    }
+
+    renderWhenReady();
+    if (widgetId === null) {
+      timer = window.setInterval(renderWhenReady, 100);
+    }
+
+    return () => {
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+      }
+      if (widgetId !== null && window.turnstile?.remove) {
+        window.turnstile.remove(widgetId);
+      }
+    };
+  }, [onExpire, onToken, siteKey]);
+
+  return <div ref={containerRef} />;
+}
+
+function ensureTurnstileScript() {
+  if (typeof window === "undefined" || window.turnstile || window.__g6TurnstileScriptLoading) {
+    return;
+  }
+  window.__g6TurnstileScriptLoading = true;
+  const script = document.createElement("script");
+  script.async = true;
+  script.defer = true;
+  script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+  document.head.appendChild(script);
 }

--- a/src/components/analysis/AnalysisWorkspace.tsx
+++ b/src/components/analysis/AnalysisWorkspace.tsx
@@ -228,6 +228,7 @@ export function AnalysisWorkspace() {
     let cancelled = false;
     let timer: number | undefined;
     const abortController = new AbortController();
+    const pollStartedAt = Date.now();
 
     async function poll() {
       try {
@@ -248,10 +249,16 @@ export function AnalysisWorkspace() {
             : "polling",
         );
         if (!isTerminalGameAnalysisStatus(snapshot.status)) {
-          timer = window.setTimeout(poll, 1200);
+          timer = window.setTimeout(poll, nextPollDelayMs(pollStartedAt));
         }
       } catch (error) {
         if (cancelled || isAbortError(error)) {
+          return;
+        }
+        if (error instanceof ApiError && error.status === 429) {
+          setImportStatus("polling");
+          setImportError(importErrorMessage(error));
+          timer = window.setTimeout(poll, retryAfterDelayMs(error));
           return;
         }
         setImportStatus("failed");
@@ -1723,12 +1730,38 @@ function clearStoredGameAnalysisJob(): void {
 
 function importErrorMessage(error: unknown): string {
   if (error instanceof ApiError) {
+    if (error.status === 429 && error.retryAfterSeconds !== null) {
+      return `Too many requests. Try again in ${formatRetryAfter(error.retryAfterSeconds)}.`;
+    }
     return error.detail;
   }
   if (error instanceof Error) {
     return error.message;
   }
   return "Import failed.";
+}
+
+function nextPollDelayMs(pollStartedAt: number): number {
+  const elapsedMs = Date.now() - pollStartedAt;
+  if (elapsedMs < 20_000) {
+    return 1200;
+  }
+  if (elapsedMs < 120_000) {
+    return 3000;
+  }
+  return 7000;
+}
+
+function retryAfterDelayMs(error: ApiError): number {
+  return Math.max(1000, (error.retryAfterSeconds ?? 5) * 1000);
+}
+
+function formatRetryAfter(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
 }
 
 function buildMoveLoadingIndicator(

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getCachedChessComLiveGameAnalysis, startImportedGameAnalysis } from "./api";
+import { type ApiError, getCachedChessComLiveGameAnalysis, startImportedGameAnalysis } from "./api";
 
 describe("startImportedGameAnalysis", () => {
   afterEach(() => {
@@ -79,5 +79,37 @@ describe("startImportedGameAnalysis", () => {
       "http://127.0.0.1:8001/api/game-analysis/import/chess-com/live/168193636078",
       {},
     );
+  });
+
+  it("preserves backend error code and Retry-After for rate limits", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            detail: {
+              code: "import_start_rate_limited",
+              message: "Too many requests. Try again after the cooldown.",
+            },
+          }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "30",
+            },
+          },
+        ),
+      ),
+    );
+
+    await expect(
+      startImportedGameAnalysis({ source: "pgn", pgn: "1. e4 e5 *" }),
+    ).rejects.toMatchObject({
+      status: 429,
+      code: "import_start_rate_limited",
+      retryAfterSeconds: 30,
+      detail: "Too many requests. Try again after the cooldown.",
+    } satisfies Partial<ApiError>);
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,12 +36,20 @@ export async function pollGameAnalysis(
 export class ApiError extends Error {
   readonly status: number;
   readonly detail: string;
+  readonly code: string | null;
+  readonly retryAfterSeconds: number | null;
 
-  constructor(status: number, detail: string) {
+  constructor(
+    status: number,
+    detail: string,
+    options: { code?: string | null; retryAfterSeconds?: number | null } = {},
+  ) {
     super(detail);
     this.name = "ApiError";
     this.status = status;
     this.detail = detail;
+    this.code = options.code ?? null;
+    this.retryAfterSeconds = options.retryAfterSeconds ?? null;
   }
 }
 
@@ -77,11 +85,61 @@ function apiUrl(pathOrUrl: string): string {
 
 async function apiError(response: Response): Promise<ApiError> {
   const fallback = `API request failed with ${response.status}`;
+  const retryAfterSeconds = retryAfterSecondsFromHeader(response.headers.get("Retry-After"));
   try {
-    const payload = (await response.json()) as { detail?: unknown };
-    const detail = typeof payload.detail === "string" ? payload.detail : fallback;
-    return new ApiError(response.status, detail);
+    const payload = (await response.json()) as {
+      detail?: unknown;
+      code?: unknown;
+      message?: unknown;
+    };
+    const parsed = parseApiErrorPayload(payload, fallback);
+    return new ApiError(response.status, parsed.detail, {
+      code: parsed.code,
+      retryAfterSeconds,
+    });
   } catch {
-    return new ApiError(response.status, fallback);
+    return new ApiError(response.status, fallback, { retryAfterSeconds });
   }
+}
+
+function parseApiErrorPayload(
+  payload: { detail?: unknown; code?: unknown; message?: unknown },
+  fallback: string,
+): { detail: string; code: string | null } {
+  if (typeof payload.detail === "string") {
+    return {
+      detail: payload.detail,
+      code: typeof payload.code === "string" ? payload.code : null,
+    };
+  }
+  if (isObject(payload.detail)) {
+    const detail = payload.detail as { code?: unknown; message?: unknown };
+    return {
+      detail: typeof detail.message === "string" ? detail.message : fallback,
+      code: typeof detail.code === "string" ? detail.code : null,
+    };
+  }
+  return {
+    detail: typeof payload.message === "string" ? payload.message : fallback,
+    code: typeof payload.code === "string" ? payload.code : null,
+  };
+}
+
+function retryAfterSecondsFromHeader(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const seconds = Number.parseInt(value, 10);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return seconds;
+  }
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) {
+    return null;
+  }
+  return Math.max(1, Math.ceil((date - Date.now()) / 1000));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -243,6 +243,7 @@ export interface GameAnalysisImportRequest {
   explain_significance?: SignificanceLabel[];
   include_context?: boolean;
   use_baseline_fallback?: boolean;
+  turnstile_token?: string | null;
 }
 
 export interface GameAnalysisImportResponse {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,54 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=()"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/fonts/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/stockfish/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/game/:path*",


### PR DESCRIPTION
## What changed
- Preserves backend error codes and Retry-After values in the API client.
- Makes analysis polling respect 429 cooldowns instead of failing the current job.
- Adds optional Cloudflare Turnstile widget support through VITE_G6_TURNSTILE_SITE_KEY.
- Adds Vercel security headers and immutable caching for static assets, fonts, and Stockfish files.

## Product gain
- A user who hits a backend rate limit sees a cooldown and the app waits instead of hammering the API.
- Turnstile can be switched on from environment config without another frontend code change.
- The production frontend now ships with baseline browser security headers and long-lived static asset caching.

## Validation
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- Production deploy completed and aliased to https://www.g6chess.com
- Verified production headers on https://www.g6chess.com and immutable cache headers on the JS asset