### PR TITLE
Move Turnstile below import cards

### DIFF
--- a/src/components/analysis/AnalysisImportPanel.test.tsx
+++ b/src/components/analysis/AnalysisImportPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AnalysisImportPanel } from "./AnalysisImportPanel";
@@ -6,6 +6,11 @@ import { AnalysisImportPanel } from "./AnalysisImportPanel";
 describe("AnalysisImportPanel", () => {
   afterEach(() => {
     cleanup();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    vi.resetModules();
+    delete window.turnstile;
+    delete window.__g6TurnstileScriptLoading;
   });
 
   it("surfaces the URL import error inline and highlights the PGN toggle", async () => {
@@ -67,5 +72,37 @@ describe("AnalysisImportPanel", () => {
       use_baseline_fallback: false,
       explain_significance: ["critical"],
     });
+  });
+
+  it("renders Turnstile below the cards and hides it after verification", async () => {
+    vi.stubEnv("VITE_G6_TURNSTILE_SITE_KEY", "site-key");
+    vi.resetModules();
+
+    let verifyTurnstile: ((token: string) => void) | undefined;
+    const removeTurnstile = vi.fn();
+    window.turnstile = {
+      render: vi.fn((container, options) => {
+        container.dataset.testid = "turnstile-widget";
+        container.textContent = "Turnstile challenge";
+        verifyTurnstile = options.callback;
+        return "widget-id";
+      }),
+      remove: removeTurnstile,
+    };
+
+    const { AnalysisImportPanel: PanelWithTurnstile } = await import("./AnalysisImportPanel");
+
+    render(<PanelWithTurnstile error={null} onImport={vi.fn()} status="idle" />);
+
+    const turnstile = await screen.findByTestId("turnstile-widget");
+    const feedbackCard = screen.getByRole("link", { name: /Leave feedback/i });
+    expect(feedbackCard.compareDocumentPosition(turnstile)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    act(() => {
+      verifyTurnstile?.("verified-token");
+    });
+
+    await waitFor(() => expect(screen.queryByTestId("turnstile-widget")).toBeNull());
+    expect(removeTurnstile).toHaveBeenCalledWith("widget-id");
   });
 });

--- a/src/components/analysis/AnalysisImportPanel.tsx
+++ b/src/components/analysis/AnalysisImportPanel.tsx
@@ -58,6 +58,7 @@ export function AnalysisImportPanel({
 
   const isBusy = status === "submitting" || status === "polling";
   const needsTurnstile = TURNSTILE_SITE_KEY.length > 0;
+  const shouldShowTurnstile = needsTurnstile && turnstileToken === null;
   const displayedError = localError ?? error;
   const value = mode === "url" ? url : pgn;
   const canSubmit =
@@ -122,17 +123,6 @@ export function AnalysisImportPanel({
         />
       </form>
 
-      {needsTurnstile ? (
-        <div className="mt-3 flex justify-center">
-          <TurnstileWidget
-            key={turnstileResetKey}
-            onExpire={handleTurnstileExpire}
-            onToken={setTurnstileToken}
-            siteKey={TURNSTILE_SITE_KEY}
-          />
-        </div>
-      ) : null}
-
       <div className="mt-2 flex items-center justify-between gap-3 px-1">
         <ModeToggle
           alert={mode === "url" && Boolean(localError)}
@@ -143,6 +133,17 @@ export function AnalysisImportPanel({
       </div>
 
       <SuggestionCards />
+
+      {shouldShowTurnstile ? (
+        <div className="mt-8 flex justify-center">
+          <TurnstileWidget
+            key={turnstileResetKey}
+            onExpire={handleTurnstileExpire}
+            onToken={setTurnstileToken}
+            siteKey={TURNSTILE_SITE_KEY}
+          />
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Move the Cloudflare Turnstile widget below the import suggestion cards.
- Hide the widget completely after Turnstile returns a token, while preserving the existing reset path after backend rejection.
- Add a regression test for placement and post-verification hiding.

## Validation
- bunx biome check src/components/analysis/AnalysisImportPanel.tsx src/components/analysis/AnalysisImportPanel.test.tsx
- bun run typecheck
- bun run test src/components/analysis/AnalysisImportPanel.test.tsx
- bun run build